### PR TITLE
Add Exit Menu functionality and scene management and house if win to next level ,level1-level2,2-3,3,credit

### DIFF
--- a/Assets/Game/Buildings/House/HouseController.cs
+++ b/Assets/Game/Buildings/House/HouseController.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Collections;
+using Game;
 
 public delegate void Win();
 
@@ -9,11 +12,99 @@ namespace Game.Buildings.House
     {
         public event Win OnWin;
 
+        [Header("Level Progression")]
+        [SerializeField] private bool autoProgressToNextLevel = true;
+        [SerializeField] private float delayBeforeSceneChange = 2.0f;
+        [SerializeField] private bool showWinMessage = true;
+
+        private void Awake()
+        {
+            // Tidak perlu mencari ChangeScene component, kita akan menggunakan SceneManager langsung
+        }
+
         private void OnTriggerEnter2D(Collider2D col)
         {
             if (col.gameObject.layer != Global.Layers.PlayerID) return;
 
             OnWin?.Invoke();
+
+            if (showWinMessage)
+            {
+                Debug.Log("🎉 Level Complete! Moving to next level...");
+            }
+
+            if (autoProgressToNextLevel)
+            {
+                // Delay sebelum pindah scene untuk memberikan feedback
+                StartCoroutine(DelayedProgressToNextLevel());
+            }
+        }
+
+        private IEnumerator DelayedProgressToNextLevel()
+        {
+            yield return new WaitForSeconds(delayBeforeSceneChange);
+            ProgressToNextLevel();
+        }
+
+        private void ProgressToNextLevel()
+        {
+            string currentScene = SceneManager.GetActiveScene().name;
+
+            switch (currentScene)
+            {
+                case SceneNames.Level_01:
+                    Debug.Log("Progressing from Level 1 to Level 2");
+                    LoadScene(SceneNames.Level_02);
+                    break;
+
+                case SceneNames.Level_02:
+                    Debug.Log("Progressing from Level 2 to Level 3");
+                    LoadScene(SceneNames.Level_03);
+                    break;
+
+                case SceneNames.Level_03:
+                    Debug.Log("Level 3 completed! Going to Credits");
+                    LoadScene(SceneNames.Credits);
+                    break;
+
+                case SceneNames.Level_Bonus:
+                    Debug.Log("Bonus Level completed! Going to Credits");
+                    LoadScene(SceneNames.Credits);
+                    break;
+
+                default:
+                    Debug.LogWarning($"No next level defined for scene: {currentScene}. Going to Main Menu.");
+                    LoadScene(SceneNames.MainMenu);
+                    break;
+            }
+        }
+
+        private void LoadScene(string sceneName)
+        {
+            // Reset session stats saat pindah level
+            GameStats.ResetSessionStats();
+
+            Debug.Log($"Loading scene: {sceneName}");
+            SceneManager.LoadScene(sceneName);
+        }
+
+        // Method untuk manual progression (bisa dipanggil dari UI button)
+        public void ManualProgressToNextLevel()
+        {
+            ProgressToNextLevel();
+        }
+
+        // Method untuk kembali ke main menu
+        public void GoToMainMenu()
+        {
+            LoadScene(SceneNames.MainMenu);
+        }
+
+        // Method untuk restart level
+        public void RestartLevel()
+        {
+            string currentScene = SceneManager.GetActiveScene().name;
+            LoadScene(currentScene);
         }
     }
 }

--- a/Assets/Game/Scenes/ExitGame.meta
+++ b/Assets/Game/Scenes/ExitGame.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ce23302f3454b6408d89512f62cf20c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Scenes/ExitGame/ExitGame.unity
+++ b/Assets/Game/Scenes/ExitGame/ExitGame.unity
@@ -1,0 +1,768 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &195622206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 195622207}
+  - component: {fileID: 195622211}
+  - component: {fileID: 195622210}
+  - component: {fileID: 195622209}
+  - component: {fileID: 195622208}
+  m_Layer: 5
+  m_Name: No
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &195622207
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195622206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1338866502}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 72, y: -44.08}
+  m_SizeDelta: {x: 125.52, y: 52.17}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &195622208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195622206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
+--- !u!114 &195622209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195622206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 195622210}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 195622208}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToMainMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &195622210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195622206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 3310002292416464744, guid: dbae0a8caec66964ebd7747f094f3232, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &195622211
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 195622206}
+  m_CullTransparentMesh: 1
+--- !u!1 &540142403
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 540142406}
+  - component: {fileID: 540142405}
+  - component: {fileID: 540142404}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &540142404
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540142403}
+  m_Enabled: 1
+--- !u!20 &540142405
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540142403}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &540142406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540142403}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &720317605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 720317606}
+  - component: {fileID: 720317610}
+  - component: {fileID: 720317609}
+  - component: {fileID: 720317608}
+  - component: {fileID: 720317607}
+  m_Layer: 5
+  m_Name: Yes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &720317606
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720317605}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1338866502}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -73.63, y: -44.08}
+  m_SizeDelta: {x: 125.52, y: 52.17}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &720317607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720317605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
+--- !u!114 &720317608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720317605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 720317609}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 720317607}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToMainMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &720317609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720317605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 6729492362831431167, guid: 192d6b36a458eed4e9bff2ca219ebecb, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &720317610
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720317605}
+  m_CullTransparentMesh: 1
+--- !u!1 &1177256441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1177256442}
+  - component: {fileID: 1177256444}
+  - component: {fileID: 1177256443}
+  m_Layer: 5
+  m_Name: Card
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1177256442
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1177256441}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1338866502}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00012207, y: 5.52}
+  m_SizeDelta: {x: 380.97, y: 222.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1177256443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1177256441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -4781373940957465942, guid: 9960b1adc3a6ada40ac197c709113986, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1177256444
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1177256441}
+  m_CullTransparentMesh: 1
+--- !u!1 &1338866498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1338866502}
+  - component: {fileID: 1338866501}
+  - component: {fileID: 1338866500}
+  - component: {fileID: 1338866499}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1338866499
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338866498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1338866500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338866498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1338866501
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338866498}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1338866502
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338866498}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1645798678}
+  - {fileID: 1177256442}
+  - {fileID: 720317606}
+  - {fileID: 195622207}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1645798677
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1645798678}
+  - component: {fileID: 1645798680}
+  - component: {fileID: 1645798679}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1645798678
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645798677}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1338866502}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00013402, y: 5.52}
+  m_SizeDelta: {x: 800, y: 573.17}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1645798679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645798677}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 123054049716070046, guid: 0371880b8aa047845a4a3350fee7d94e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1645798680
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645798677}
+  m_CullTransparentMesh: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 540142406}
+  - {fileID: 1338866502}

--- a/Assets/Game/Scenes/ExitGame/ExitGame.unity.meta
+++ b/Assets/Game/Scenes/ExitGame/ExitGame.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ee9feb986077b30489e2f79a218d0e52
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Scenes/ExitMenu/ExitMenu.unity
+++ b/Assets/Game/Scenes/ExitMenu/ExitMenu.unity
@@ -175,6 +175,7 @@ GameObject:
   - component: {fileID: 50074883}
   - component: {fileID: 50074882}
   - component: {fileID: 50074881}
+  - component: {fileID: 50074884}
   m_Layer: 5
   m_Name: Yes
   m_TagString: Untagged
@@ -245,9 +246,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 21039047}
-        m_TargetAssemblyTypeName: ExitMenu, Global
-        m_MethodName: OnYesButtonClicked
+      - m_Target: {fileID: 50074884}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: ExitGame
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -295,6 +296,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 50074879}
   m_CullTransparentMesh: 1
+--- !u!114 &50074884
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 50074879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1 &144641743
 GameObject:
   m_ObjectHideFlags: 0
@@ -733,6 +748,7 @@ GameObject:
   - component: {fileID: 2063619044}
   - component: {fileID: 2063619043}
   - component: {fileID: 2063619042}
+  - component: {fileID: 2063619045}
   m_Layer: 5
   m_Name: No
   m_TagString: Untagged
@@ -803,9 +819,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 21039047}
-        m_TargetAssemblyTypeName: ExitMenu, Global
-        m_MethodName: OnNoButtonClicked
+      - m_Target: {fileID: 2063619045}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToMainMenu
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -853,6 +869,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2063619040}
   m_CullTransparentMesh: 1
+--- !u!114 &2063619045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063619040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Game/Scenes/ExitMenu/Scripts.meta
+++ b/Assets/Game/Scenes/ExitMenu/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7bc68c037a343f42918a98f973b900b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Scenes/ExitMenu/Scripts/ExitMenuController.cs
+++ b/Assets/Game/Scenes/ExitMenu/Scripts/ExitMenuController.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Game;
+
+public class ExitMenuController : MonoBehaviour
+{
+    private void Start()
+    {
+        // Tampilkan cursor
+        Cursor.visible = true;
+
+        // Log untuk debug
+        string lastLevel = PlayerPrefs.GetString("LastPlayedLevel", SceneNames.MainMenu);
+        Debug.Log($"Exit Menu opened from level: {lastLevel}");
+    }
+
+    private void Update()
+    {
+        // ESC untuk langsung kembali ke game (sama seperti tombol No)
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            OnNoClicked();
+        }
+    }
+
+    // Method untuk tombol "Yes" - Kembali ke Main Menu
+    public void OnYesClicked()
+    {
+        Debug.Log("Yes clicked - Going to Main Menu");
+
+        // Hapus data level yang disimpan
+        PlayerPrefs.DeleteKey("LastPlayedLevel");
+
+        // Reset session stats
+        GameStats.ResetSessionStats();
+
+        // Kembali ke Main Menu
+        SceneManager.LoadScene(SceneNames.MainMenu);
+    }
+
+    // Method untuk tombol "No" - Lanjut main game
+    public void OnNoClicked()
+    {
+        Debug.Log("No clicked - Returning to game");
+
+        // Ambil level yang disimpan
+        string lastLevel = PlayerPrefs.GetString("LastPlayedLevel", SceneNames.MainMenu);
+
+        // Validasi apakah level valid
+        if (IsValidGameLevel(lastLevel))
+        {
+            Debug.Log($"Returning to level: {lastLevel}");
+            SceneManager.LoadScene(lastLevel);
+        }
+        else
+        {
+            Debug.LogWarning($"Invalid level: {lastLevel}. Going to Main Menu instead.");
+            SceneManager.LoadScene(SceneNames.MainMenu);
+        }
+    }
+
+    // Method untuk tombol "Exit Game" - Keluar dari aplikasi
+    public void OnExitGameClicked()
+    {
+        Debug.Log("Exit Game clicked - Quitting application");
+
+        // Hapus data level yang disimpan
+        PlayerPrefs.DeleteKey("LastPlayedLevel");
+
+        // Keluar dari aplikasi
+        Application.Quit();
+
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#endif
+    }
+
+    private bool IsValidGameLevel(string levelName)
+    {
+        return levelName == SceneNames.Level_01 ||
+               levelName == SceneNames.Level_02 ||
+               levelName == SceneNames.Level_03 ||
+               levelName == SceneNames.Level_Bonus;
+    }
+}

--- a/Assets/Game/Scenes/ExitMenu/Scripts/ExitMenuController.cs.meta
+++ b/Assets/Game/Scenes/ExitMenu/Scripts/ExitMenuController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 370bb22e243dfa0409f7bc26d1a385c6

--- a/Assets/Game/Scenes/MainMenu/Assets/Scripts/ChangeScene.cs
+++ b/Assets/Game/Scenes/MainMenu/Assets/Scripts/ChangeScene.cs
@@ -4,40 +4,248 @@ using Game;
 
 public class ChangeScene : MonoBehaviour
 {
-    public void GoToCredits()
-    {
-        SceneManager.LoadScene("Credits");
-    }
+    [Header("Scene Navigation")]
+    [SerializeField] private bool resetStatsOnSceneChange = true;
+    [SerializeField] private bool enableDebugLogging = true;
 
+    #region Public Scene Change Methods
+
+    // Main Menu Navigation
     public void GoToMainMenu()
     {
-        // Reset session stats when going to main menu
-        GameStats.ResetSessionStats();
-        SceneManager.LoadScene("MainMenu");
+        LoadScene(GameScene.MainMenu);
     }
 
+    public void GoToCredits()
+    {
+        LoadScene(GameScene.Credits);
+    }
+
+    public void GoToExitMenu()
+    {
+        LoadScene(GameScene.ExitMenu);
+    }
+
+    public void GoToShopMenu()
+    {
+        LoadScene(GameScene.ShopMenu);
+    }
+
+    // Level Navigation
     public void GoToLevel1()
     {
-        // Reset session stats when starting level
-        GameStats.ResetSessionStats();
-        SceneManager.LoadScene("Level_01");
+        LoadScene(GameScene.Level_01);
     }
+
+    public void GoToLevel2()
+    {
+        LoadScene(GameScene.Level_02);
+    }
+
+    public void GoToLevel3()
+    {
+        LoadScene(GameScene.Level_03);
+    }
+
+    public void GoToBonusLevel()
+    {
+        LoadScene(GameScene.Level_Bonus);
+    }
+
+    // Navigation by String (untuk backward compatibility)
+    public void GoToScene(string sceneName)
+    {
+        LoadSceneByName(sceneName);
+    }
+
+    // Navigation by Enum
+    public void GoToScene(GameScene scene)
+    {
+        LoadScene(scene);
+    }
+
+    // Level progression (next/previous)
+    public void GoToNextLevel()
+    {
+        string currentScene = SceneManager.GetActiveScene().name;
+
+        switch (currentScene)
+        {
+            case SceneNames.Level_01:
+                LoadScene(GameScene.Level_02);
+                break;
+            case SceneNames.Level_02:
+                LoadScene(GameScene.Level_03);
+                break;
+            case SceneNames.Level_03:
+                LoadScene(GameScene.Level_Bonus);
+                break;
+            case SceneNames.Level_Bonus:
+                LoadScene(GameScene.MainMenu); // Kembali ke menu setelah bonus level
+                break;
+            default:
+                LogDebug($"No next level defined for scene: {currentScene}");
+                break;
+        }
+    }
+
+    public void GoToPreviousLevel()
+    {
+        string currentScene = SceneManager.GetActiveScene().name;
+
+        switch (currentScene)
+        {
+            case SceneNames.Level_02:
+                LoadScene(GameScene.Level_01);
+                break;
+            case SceneNames.Level_03:
+                LoadScene(GameScene.Level_02);
+                break;
+            case SceneNames.Level_Bonus:
+                LoadScene(GameScene.Level_03);
+                break;
+            default:
+                LoadScene(GameScene.MainMenu); // Default kembali ke menu
+                break;
+        }
+    }
+
+    // Restart current level
+    public void RestartCurrentLevel()
+    {
+        string currentScene = SceneManager.GetActiveScene().name;
+        LoadSceneByName(currentScene);
+    }
+
+    #endregion
+
+    #region Core Scene Loading Methods
+
+    private void LoadScene(GameScene scene)
+    {
+        string sceneName = GetSceneName(scene);
+        LoadSceneByName(sceneName);
+    }
+
+    private void LoadSceneByName(string sceneName)
+    {
+        LogDebug($"Loading scene: {sceneName}");
+
+        // Reset stats jika diaktifkan dan scene adalah level atau menu utama
+        if (resetStatsOnSceneChange && ShouldResetStats(sceneName))
+        {
+            GameStats.ResetSessionStats();
+            LogDebug("Session stats reset");
+        }
+
+        // Load scene
+        SceneManager.LoadScene(sceneName);
+    }
+
+    private string GetSceneName(GameScene scene)
+    {
+        return scene switch
+        {
+            GameScene.MainMenu => SceneNames.MainMenu,
+            GameScene.Credits => SceneNames.Credits,
+            GameScene.ExitMenu => SceneNames.ExitMenu,
+            GameScene.ShopMenu => SceneNames.ShopMenu,
+            GameScene.Level_01 => SceneNames.Level_01,
+            GameScene.Level_02 => SceneNames.Level_02,
+            GameScene.Level_03 => SceneNames.Level_03,
+            GameScene.Level_Bonus => SceneNames.Level_Bonus,
+            _ => SceneNames.MainMenu
+        };
+    }
+
+    private bool ShouldResetStats(string sceneName)
+    {
+        // Reset stats saat masuk ke main menu atau mulai level baru
+        return sceneName == SceneNames.MainMenu ||
+               sceneName == SceneNames.Level_01 ||
+               sceneName == SceneNames.Level_02 ||
+               sceneName == SceneNames.Level_03 ||
+               sceneName == SceneNames.Level_Bonus;
+    }
+
+    #endregion
+
+    #region Utility Methods
 
     public void ExitGame()
     {
+        LogDebug("Exiting game...");
         Application.Quit();
-        Debug.Log("Game Closed"); // agar terlihat saat test di editor
+
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#endif
     }
+
+    public string GetCurrentSceneName()
+    {
+        return SceneManager.GetActiveScene().name;
+    }
+
+    public bool IsInLevel()
+    {
+        string currentScene = GetCurrentSceneName();
+        return currentScene.Contains("Level_");
+    }
+
+    public bool IsInMenu()
+    {
+        string currentScene = GetCurrentSceneName();
+        return currentScene == SceneNames.MainMenu ||
+               currentScene == SceneNames.Credits ||
+               currentScene == SceneNames.ExitMenu ||
+               currentScene == SceneNames.ShopMenu;
+    }
+
+    private void LogDebug(string message)
+    {
+        if (enableDebugLogging)
+        {
+            Debug.Log($"[ChangeScene] {message}");
+        }
+    }
+
+    #endregion
+
+    #region Input Handling
 
     void Update()
     {
-        // ESC hanya aktif di scene Credits agar tidak mengganggu scene lain
-        if (SceneManager.GetActiveScene().name == "Credits")
+        HandleEscapeInput();
+    }
+
+    private void HandleEscapeInput()
+    {
+        if (!Input.GetKeyDown(KeyCode.Escape)) return;
+
+        string currentScene = GetCurrentSceneName();
+
+        switch (currentScene)
         {
-            if (Input.GetKeyDown(KeyCode.Escape))
-            {
+            case SceneNames.Credits:
                 GoToMainMenu();
-            }
+                break;
+            case SceneNames.ExitMenu:
+                GoToMainMenu();
+                break;
+            case SceneNames.ShopMenu:
+                GoToMainMenu();
+                break;
+            // Untuk level, bisa kembali ke menu atau pause game
+            case SceneNames.Level_01:
+            case SceneNames.Level_02:
+            case SceneNames.Level_03:
+            case SceneNames.Level_Bonus:
+                // Implementasi pause menu bisa ditambahkan di sini
+                LogDebug("ESC pressed in level - implement pause menu here");
+                break;
         }
     }
+
+    #endregion
 }

--- a/Assets/Game/Scenes/MainMenu/MainMenu.unity
+++ b/Assets/Game/Scenes/MainMenu/MainMenu.unity
@@ -294,6 +294,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!4 &466893026
 Transform:
   m_ObjectHideFlags: 0
@@ -819,6 +821,7 @@ GameObject:
   - component: {fileID: 1027792502}
   - component: {fileID: 1027792501}
   - component: {fileID: 1027792504}
+  - component: {fileID: 1027792505}
   m_Layer: 5
   m_Name: ExitButton
   m_TagString: Untagged
@@ -890,9 +893,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1027792504}
-        m_TargetAssemblyTypeName: Game.Scenes.MainMenu.ExitButtonController, MainMenu
-        m_MethodName: OnClick
+      - m_Target: {fileID: 1027792505}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToExitMenu
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -952,6 +955,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df28b6ea714fb8d488ec304f15d8aa60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1027792505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1027792499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1 &1093772705
 GameObject:
   m_ObjectHideFlags: 0
@@ -1692,6 +1709,7 @@ GameObject:
   - component: {fileID: 1632449655}
   - component: {fileID: 1632449654}
   - component: {fileID: 1632449653}
+  - component: {fileID: 1632449657}
   m_Layer: 5
   m_Name: ShopButton
   m_TagString: Untagged
@@ -1775,9 +1793,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1632449653}
-        m_TargetAssemblyTypeName: Game.Scenes.MainMenu.PlayButtonController, MainMenu
-        m_MethodName: OnClick
+      - m_Target: {fileID: 1632449657}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToShopMenu
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1825,6 +1843,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1632449651}
   m_CullTransparentMesh: 1
+--- !u!114 &1632449657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632449651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1 &1751431670
 GameObject:
   m_ObjectHideFlags: 0
@@ -1838,6 +1870,7 @@ GameObject:
   - component: {fileID: 1751431673}
   - component: {fileID: 1751431672}
   - component: {fileID: 1751431675}
+  - component: {fileID: 1751431676}
   m_Layer: 5
   m_Name: PlayButton
   m_TagString: Untagged
@@ -1909,9 +1942,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1751431675}
-        m_TargetAssemblyTypeName: Game.Scenes.MainMenu.PlayButtonController, MainMenu
-        m_MethodName: OnClick
+      - m_Target: {fileID: 1751431676}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToLevel1
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1971,6 +2004,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bbd8eb648be359c4ab71548ff9fdf9a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1751431676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751431670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Game/Scenes/ShopMenu/ShopMenu.unity
+++ b/Assets/Game/Scenes/ShopMenu/ShopMenu.unity
@@ -205,6 +205,8 @@ GameObject:
   - component: {fileID: 151559364}
   - component: {fileID: 151559366}
   - component: {fileID: 151559365}
+  - component: {fileID: 151559368}
+  - component: {fileID: 151559367}
   m_Layer: 5
   m_Name: Back
   m_TagString: Untagged
@@ -229,8 +231,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -746, y: 390}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: -764.68, y: 396.67}
+  m_SizeDelta: {x: 89.32, y: 86.65}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &151559365
 MonoBehaviour:
@@ -270,6 +272,76 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 151559363}
   m_CullTransparentMesh: 1
+--- !u!114 &151559367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 151559363}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 151559365}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 151559368}
+        m_TargetAssemblyTypeName: ChangeScene, MainMenu
+        m_MethodName: GoToMainMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &151559368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 151559363}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a227bb1a42df3747a4ed661791d52f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  resetStatsOnSceneChange: 1
+  enableDebugLogging: 1
 --- !u!1 &182535889
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Game/Scripts.meta
+++ b/Assets/Game/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a40f29e20a64aa4086d0c03ca2ddfba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Scripts/SceneNames.cs
+++ b/Assets/Game/Scripts/SceneNames.cs
@@ -1,0 +1,32 @@
+namespace Game
+{
+    public static class SceneNames
+    {
+        // Main Scenes
+        public const string MainMenu = "MainMenu";
+        public const string Credits = "Credits";
+        public const string ExitMenu = "ExitMenu";
+        public const string ShopMenu = "ShopMenu";
+
+        // Level Scenes
+        public const string Level_01 = "Level_01";
+        public const string Level_02 = "Level_02";
+        public const string Level_03 = "Level_03";
+        public const string Level_Bonus = "Level_Bonus";
+
+        // Template (biasanya tidak digunakan untuk gameplay)
+        public const string URP2DSceneTemplate = "URP2DSceneTemplate";
+    }
+
+    public enum GameScene
+    {
+        MainMenu,
+        Credits,
+        ExitMenu,
+        ShopMenu,
+        Level_01,
+        Level_02,
+        Level_03,
+        Level_Bonus
+    }
+}

--- a/Assets/Game/Scripts/SceneNames.cs.meta
+++ b/Assets/Game/Scripts/SceneNames.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7d1beab63f74424f859fa0d7210680e

--- a/Assets/Imported/HUD/key-game (1500 x 500 piksel) (1).png.meta
+++ b/Assets/Imported/HUD/key-game (1500 x 500 piksel) (1).png.meta
@@ -272,7 +272,13 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (1500 x 500 piksel) (1)_0: 8195668861087505689
+      key-game (1500 x 500 piksel) (1)_1: 1316289426823555865
+      key-game (1500 x 500 piksel) (1)_2: -6412631584946486169
+      key-game (1500 x 500 piksel) (1)_3: -406916875492637688
+      key-game (1500 x 500 piksel) (1)_4: -6380693414189278355
+      key-game (1500 x 500 piksel) (1)_5: -5431570819543444598
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Imported/HUD/key-game (1500 x 500 piksel) (2).png.meta
+++ b/Assets/Imported/HUD/key-game (1500 x 500 piksel) (2).png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (1500 x 500 piksel) (2)_0: 8490123032128456281
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Imported/HUD/key-game (1500 x 500 piksel) (3).png.meta
+++ b/Assets/Imported/HUD/key-game (1500 x 500 piksel) (3).png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (1500 x 500 piksel) (3)_0: 6226471454036379121
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Imported/HUD/key-game (1500 x 500 piksel).png.meta
+++ b/Assets/Imported/HUD/key-game (1500 x 500 piksel).png.meta
@@ -222,7 +222,11 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (1500 x 500 piksel)_0: -2211508660350780660
+      key-game (1500 x 500 piksel)_1: 18174380485636190
+      key-game (1500 x 500 piksel)_2: 6263437443224442637
+      key-game (1500 x 500 piksel)_3: -7250730662712457630
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Imported/HUD/key-game (6).png.meta
+++ b/Assets/Imported/HUD/key-game (6).png.meta
@@ -172,7 +172,9 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (6)_0: 1845324038128672951
+      key-game (6)_1: -6222878660504342853
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Imported/HUD/key-game (7).png.meta
+++ b/Assets/Imported/HUD/key-game (7).png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      key-game (7)_0: -1338666416529479819
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Settings.meta
+++ b/Assets/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 926f51fcde0df3d4ab7bc7d9331574dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Build Profiles.meta
+++ b/Assets/Settings/Build Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4911c482a604f0849b6d1186501cb5a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Build Profiles/New Windows Profile.asset
+++ b/Assets/Settings/Build Profiles/New Windows Profile.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: New Windows Profile
+  m_EditorClassIdentifier: 
+  m_AssetVersion: 1
+  m_BuildTarget: 19
+  m_Subtarget: 2
+  m_PlatformId: 4e3c793746204150860bf175a9a41a05
+  m_PlatformBuildProfile:
+    rid: -2
+  m_OverrideGlobalSceneList: 0
+  m_Scenes: []
+  m_ScriptingDefines: []
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Assets/Settings/Build Profiles/New Windows Profile.asset.meta
+++ b/Assets/Settings/Build Profiles/New Windows Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3bf295355a9d6a5499d8875571814c07
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.1.7",
+      "version": "1.1.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -102,7 +102,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.18",
+      "version": "1.8.19",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -149,7 +149,7 @@
         "com.unity.2d.spriteshape": "10.0.7",
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.2d.tilemap.extras": "4.1.0",
-        "com.unity.2d.aseprite": "1.1.7"
+        "com.unity.2d.aseprite": "1.1.8"
       }
     },
     "com.unity.ide.rider": {
@@ -193,7 +193,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "17.0.3",
+      "version": "17.0.4",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -212,8 +212,8 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.0.3",
-        "com.unity.shadergraph": "17.0.3",
+        "com.unity.render-pipelines.core": "17.0.4",
+        "com.unity.shadergraph": "17.0.4",
         "com.unity.render-pipelines.universal-config": "17.0.3"
       }
     },
@@ -236,23 +236,23 @@
       }
     },
     "com.unity.searcher": {
-      "version": "4.9.2",
+      "version": "4.9.3",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "17.0.3",
+      "version": "17.0.4",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.0.3",
-        "com.unity.searcher": "4.9.2"
+        "com.unity.render-pipelines.core": "17.0.4",
+        "com.unity.searcher": "4.9.3"
       }
     },
     "com.unity.test-framework": {
-      "version": "1.4.5",
+      "version": "1.4.6",
       "depth": 3,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,5 +14,20 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Game/Scenes/MainMenu/Credits.unity
     guid: f8224237fb40fea48ac2cd6f9c965dd1
+  - enabled: 1
+    path: Assets/Game/Scenes/ShopMenu/ShopMenu.unity
+    guid: 00ff75b7f6e3ba34dae6bd04fb2175d1
+  - enabled: 1
+    path: Assets/Game/Scenes/ExitMenu/ExitMenu.unity
+    guid: 3fb32fe9bccabe94f8a894da20d31155
+  - enabled: 1
+    path: Assets/Game/Scenes/Level_02/Level_02.unity
+    guid: cb531a1758aa3c04cbe50a94d2ab1806
+  - enabled: 1
+    path: Assets/Game/Scenes/Level_03/Level_03.unity
+    guid: 7fbe23c8769a4554ba787fbe5afbf123
+  - enabled: 1
+    path: Assets/Game/Scenes/ExitGame/ExitGame.unity
+    guid: ee9feb986077b30489e2f79a218d0e52
   m_configObjects: {}
   m_UseUCBPForAssetBundles: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.34f1
-m_EditorVersionWithRevision: 6000.0.34f1 (5ab2d9ed9190)
+m_EditorVersion: 6000.0.40f1
+m_EditorVersionWithRevision: 6000.0.40f1 (157d81624ddf)

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -6,34 +6,34 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedSceneGuid-0:
-      value: 005350545304580a555d0d7a14770e154e154d2b297c7e327f2b4e66e0e23269
-      flags: 0
-    RecentlyUsedSceneGuid-1:
-      value: 535202545453580a5e0a0970497b0d44434f1b7f287025607b7e4e6be4b16d6f
-      flags: 0
-    RecentlyUsedSceneGuid-2:
-      value: 0509065451075a0c0b0c587216265e444e161b782f2c7036742a4465b7e43069
-      flags: 0
-    RecentlyUsedSceneGuid-3:
       value: 520100045551580f55595d26447759444e4f49737a7b2736747d1b67bbb36168
       flags: 0
-    RecentlyUsedSceneGuid-4:
+    RecentlyUsedSceneGuid-1:
       value: 5209045751060f0f0c5b5b2442720d4412161d7f7b7a73672e704831e1b16439
       flags: 0
-    RecentlyUsedSceneGuid-5:
-      value: 00030d56045758085d5b5b7742755b4414161b7e2d7920632c2c1e32b3e26769
-      flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-2:
       value: 5301520052000b0c0b58097112220c4412161d7c2e2c76642b2b4f62b5b53069
       flags: 0
+    RecentlyUsedSceneGuid-3:
+      value: 00030d56045758085d5b5b7742755b4414161b7e2d7920632c2c1e32b3e26769
+      flags: 0
+    RecentlyUsedSceneGuid-4:
+      value: 5504010551005d5a0959087642260a4446151c7e7e2c27637f794d37b6e2656d
+      flags: 0
+    RecentlyUsedSceneGuid-5:
+      value: 5057565557530c020f0d0f2312260644104f1972757c22317f791960b3b1616d
+      flags: 0
+    RecentlyUsedSceneGuid-6:
+      value: 06540d00005750035b5e5b7512700f444e4e1d782a7f7f317f784537b2e5616a
+      flags: 0
     RecentlyUsedSceneGuid-7:
-      value: 5b520d0503545b0d0c0c0a2715770748154f4d2c7d7d7e627a7d4a35b4e1646a
+      value: 5457560357060a035a58552344760a4414164f727b2e243578281b31e4b1666b
       flags: 0
     RecentlyUsedSceneGuid-8:
-      value: 005301555454580c58560d2343200f4415151d7f7c297f64297b1c31b3b8646e
+      value: 5b520d0503545b0d0c0c0a2715770748154f4d2c7d7d7e627a7d4a35b4e1646a
       flags: 0
     RecentlyUsedSceneGuid-9:
-      value: 5457560357060a035a58552344760a4414164f727b2e243578281b31e4b1666b
+      value: 005301555454580c58560d2343200f4415151d7f7c297f64297b1c31b3b8646e
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
- Implemented ExitMenuController for handling exit menu interactions.
- Added methods for navigating to the main menu, returning to the last played level, and exiting the game.
- Updated ChangeScene script to support new scene navigation including exit menu and shop menu.
- Created SceneNames class to manage scene names and added GameScene enum for better scene handling.
- Modified MainMenu and ShopMenu scenes to integrate new exit menu functionality.
- Adjusted Level_01 scene object positions for better alignment.
- Updated project settings and package dependencies to ensure compatibility with the latest Unity version.